### PR TITLE
Update .vimrc

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -180,7 +180,7 @@
 " Settings for jedi-vim
 " cd ~/.vim/bundle
 " git clone git://github.com/davidhalter/jedi-vim.git
-" let g:jedi#related_names_command = "<leader>z"
+" let g:jedi#usages_command = "<leader>z"
 " let g:jedi#popup_on_dot = 0
 " let g:jedi#popup_select_first = 0
 " map <Leader>b Oimport ipdb; ipdb.set_trace() # BREAKPOINT<C-c>


### PR DESCRIPTION
let g:jedi#usages_command = "<leader>z" is now depricated in jedi plugin. We should use g:jedi#usages_command instead
